### PR TITLE
Bump xterm to version 4.0.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  xterm: ^3.4.1
+  xterm: ^4.0.0
   async: ^2.10.0
   logging: ^1.1.1
   dart_eval: ^0.5.6


### PR DESCRIPTION
Flutter has deprecated `RawKeyEvent`